### PR TITLE
Fix task status parsing

### DIFF
--- a/src/main/java/com/sessionflow/service/impl/TaskServiceImpl.java
+++ b/src/main/java/com/sessionflow/service/impl/TaskServiceImpl.java
@@ -130,7 +130,8 @@ public class TaskServiceImpl implements TaskService {
 
     private TaskStatus parseTaskStatus(String status) {
         try {
-            return switch (status.toLowerCase()) {
+            String normalized = status.trim().toLowerCase();
+            return switch (normalized) {
                 case "pending" -> TaskStatus.PENDING;
                 case "complete" -> TaskStatus.COMPLETE;
                 default -> throw new IllegalArgumentException("Invalid task status: " + status);

--- a/src/test/java/com/sessionflow/service/impl/TaskServiceImplTest.java
+++ b/src/test/java/com/sessionflow/service/impl/TaskServiceImplTest.java
@@ -396,4 +396,25 @@ class TaskServiceImplTest {
         verify(taskRepository, never()).findByStatusOrderByCreatedAtDesc(any());
         verify(taskMapper).toResponseList(tasks);
     }
-} 
+
+    @Test
+    @DisplayName("查詢任務時狀態包含前後空白也能正確解析")
+    void getAllTasks_StatusWithWhitespace_Success() {
+        // Given
+        List<Task> tasks = List.of(task);
+        List<TaskResponse> expectedResponses = List.of(taskResponse);
+
+        when(taskRepository.findByStatusOrderByCreatedAtDesc(TaskStatus.PENDING)).thenReturn(tasks);
+        when(taskMapper.toResponseList(tasks)).thenReturn(expectedResponses);
+
+        // When
+        List<TaskResponse> result = taskService.getAllTasks("  PENDING  ");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(1);
+
+        verify(taskRepository).findByStatusOrderByCreatedAtDesc(TaskStatus.PENDING);
+        verify(taskMapper).toResponseList(tasks);
+    }
+}


### PR DESCRIPTION
## Summary
- allow whitespace around status strings when filtering tasks
- test whitespace status string

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.6)*

------
https://chatgpt.com/codex/tasks/task_e_683fa01e26fc8329bcbb1e3ea4c00e0f